### PR TITLE
Advanced Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Customize the compiled files save location by modifying the settings.json file as
 
     {
-	    "livePugCompiler.savePath":"/location to save compiled Html"
+	    "livePugCompiler.savePath": "/location to save compiled files",
+	    "livePugCompiler.saveExt": "Extension name: html, php or other",
+	    "livePugCompiler.uScoreCompile": "TRUE or FALSE for enable/disable compiling helpers files ( where has underscore symbol on filename begin )",
+	    "livePugCompiler.startFolder": "/location to set root folder for pugs files"
 	}
 	    

--- a/package.json
+++ b/package.json
@@ -47,6 +47,24 @@
 						"type": "string",
 						"default": "/Compiled-HTML",
 						"description": "The path to which the compiled HTML files will be saved.\n / refers to the workspace root."
+					},
+					"livePugCompiler.saveExt": {
+						"title":				"Files extension",
+						"type":					"string",
+						"default":				"html",
+						"description":			"Extension of compiled files. HTML, PHP or Other. Default is html files."
+					},
+					"livePugCompiler.uScoreCompile": {
+						"title":				"Вспомогательные файлы",
+						"type":					"boolean",
+						"default":				false,
+						"description":			"Compile with underscore on begin filename. Default is not compile."
+					},
+					"livePugCompiler.startFolder": {
+						"title":				"Начальный путь",
+						"type":					"string",
+						"default":				"/",
+						"description":			"Root path to pugs files for compilation. Default is workspace root path."
 					}
 				}
 			}


### PR DESCRIPTION
In these changes, I propose to create advanced settings for managing the extension.
1) Setting the type of compiled files, for example PHP.
2) Change the root folder relative to the workspace to search for PUG files.
3) Disable or enable compilation of auxiliary PUG files (files starting with an underscore character).